### PR TITLE
Update Package.swift to have swift-tools version comment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version: 5.4
+
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
TheGnuGod's original commit has the top line as `// swift-tools-version: 5.4`
If compatibility is possible maintainers might switch this to be 6.0
If 5.4 produces errors, downgrading might be necessary, but that would make the merge less useful.